### PR TITLE
Cast the is_speaking bool to i8 for Apple Silicon

### DIFF
--- a/src/backends/appkit.rs
+++ b/src/backends/appkit.rs
@@ -197,15 +197,14 @@ impl Backend for AppKit {
     }
 
     fn is_speaking(&self) -> Result<bool, Error> {
-        #[cfg(not(target_arch = "aarch64"))]
-        let yes: i8 = YES;
+        let result: i8 = unsafe { msg_send![self.0, isSpeaking] };
 
         #[cfg(target_arch = "aarch64")]
-        let yes: i8 = match YES { true => 1, false => 0 };
+        let is_speaking = result == YES as i8;
+        #[cfg(not(target_arch = "aarch64"))]
+        let is_speaking = result == YES;
 
-        let is_speaking: i8 = unsafe { msg_send![self.0, isSpeaking] };
-
-        Ok(is_speaking == yes)
+        Ok(is_speaking)
     }
 }
 

--- a/src/backends/appkit.rs
+++ b/src/backends/appkit.rs
@@ -196,6 +196,18 @@ impl Backend for AppKit {
         Ok(())
     }
 
+    #[cfg(target_arch = "aarch64")]
+    fn is_speaking(&self) -> Result<bool, Error> {
+        let is_speaking: i8 = unsafe { msg_send![self.0, isSpeaking] };
+        Ok(is_speaking == YES as i8)
+    }
+
+    #[cfg(target_arch = "x86")]
+    #[cfg(target_arch = "x86_64")]
+    #[cfg(target_arch = "mips")]
+    #[cfg(target_arch = "powerpc")]
+    #[cfg(target_arch = "powerpc64")]
+    #[cfg(target_arch = "arm")]
     fn is_speaking(&self) -> Result<bool, Error> {
         let is_speaking: i8 = unsafe { msg_send![self.0, isSpeaking] };
         Ok(is_speaking == YES)

--- a/src/backends/appkit.rs
+++ b/src/backends/appkit.rs
@@ -196,21 +196,16 @@ impl Backend for AppKit {
         Ok(())
     }
 
-    #[cfg(target_arch = "aarch64")]
     fn is_speaking(&self) -> Result<bool, Error> {
-        let is_speaking: i8 = unsafe { msg_send![self.0, isSpeaking] };
-        Ok(is_speaking == YES as i8)
-    }
+        #[cfg(not(target_arch = "aarch64"))]
+        let yes: i8 = YES;
 
-    #[cfg(target_arch = "x86")]
-    #[cfg(target_arch = "x86_64")]
-    #[cfg(target_arch = "mips")]
-    #[cfg(target_arch = "powerpc")]
-    #[cfg(target_arch = "powerpc64")]
-    #[cfg(target_arch = "arm")]
-    fn is_speaking(&self) -> Result<bool, Error> {
+        #[cfg(target_arch = "aarch64")]
+        let yes: i8 = match YES { true => 1, false => 0 };
+
         let is_speaking: i8 = unsafe { msg_send![self.0, isSpeaking] };
-        Ok(is_speaking == YES)
+
+        Ok(is_speaking == yes)
     }
 }
 


### PR DESCRIPTION
I've never used conditional compilation before and I'm a novice at Rust, so feel free to yell at me if this is crazy but - This makes the package compile on my MacBook Air M1 (Apple Silicon ARM).

Without it, this is the result:

```
error[E0308]: mismatched types
   --> src/backends/appkit.rs:204:31
    |
204 |             Ok(is_speaking == YES)
    |                               ^^^ expected `i8`, found `bool`
```