### PR TITLE
Bump ndk-glue version in Android example

### DIFF
--- a/examples/android/build.gradle
+++ b/examples/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:4.1.1"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "gradle.plugin.com.github.willir.rust:plugin:0.3.3"
+        classpath "gradle.plugin.com.github.willir.rust:plugin:0.3.4"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/examples/android/cargo.toml
+++ b/examples/android/cargo.toml
@@ -10,5 +10,5 @@ edition = "2018"
 crate-type = ["dylib"]
 
 [dependencies]
-ndk-glue = "0.2"
+ndk-glue = "0.5"
 tts = { path = "../.." }


### PR DESCRIPTION
The example currently panics in `ndk_glue::native_activity()` trying to unwrap a None value. By bumping this version (and using an emulator with a TTS) the example works.

edit: Also bumps [`gradle.plugin.com.github.willir.rust:plugin`](https://github.com/willir/cargo-ndk-android-gradle) so that it works with cargo-ndk 2+. [Commit](https://github.com/willir/cargo-ndk-android-gradle/commit/92edee7d2b73f24ef7a7734d753d01a3aa8e7b08) says it's compatible with 1.0 too. Forgot I bumped it while debugging, build fails for me without it.