### PR TITLE
Make speech-dispatcher opt-in so we can avoid LGPL by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ tolk = { version = "0.5", optional = true }
 windows = { version = "0.30", features = ["alloc", "Foundation", "Media_Core", "Media_Playback", "Media_SpeechSynthesis", "Storage_Streams"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-speech-dispatcher = "0.11"
+speech-dispatcher = { version = "0.11", optional = true } # optional, since it is using LGPL
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 cocoa-foundation = "0.1"

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(target_os = "linux")]
+#[cfg(feature = "speech_dispatcher")]
 mod speech_dispatcher;
 
 #[cfg(all(windows, feature = "tolk"))]
@@ -19,7 +19,7 @@ mod av_foundation;
 #[cfg(target_os = "android")]
 mod android;
 
-#[cfg(target_os = "linux")]
+#[cfg(feature = "speech_dispatcher")]
 pub(crate) use self::speech_dispatcher::*;
 
 #[cfg(all(windows, feature = "tolk"))]


### PR DESCRIPTION
`speech-dispatcher` uses the copy-left LGPL license, which means it cannot be used in any closed source projects. Since this is a default dependency (on linux), it means the whole `tts` crate becomes impossible to depend on for any crate that would like to _not_ be copy-left.

This PR makes it an opt-in dependency. This means using `tts` on Linux will by default result in an error, until a user actively adds the `speech-dispatcher` to `tts`.

I know this isn't ideal, and if anyone has a better suggestion, I'm all ears.

I use `tts` as an opt-in dependency of <https://crates.io/crates/egui-winit>, and this can cause situations where others may not want to depend on my crate because of the copy-left issue.

The problem was discovered thanks to https://github.com/EmbarkStudios/cargo-deny