### PR TITLE
Derive common traits for Gender and Voice

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -648,13 +648,13 @@ impl Drop for Tts {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Gender {
     Male,
     Female,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Voice {
     pub(crate) id: String,
     pub(crate) name: String,


### PR DESCRIPTION
Deriving all the common traits for `Voice` and `Gender` avoids having to use other strategies to compare them, which is often a hassle.