### PR TITLE
remove default feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ crate-type = ["lib", "cdylib", "staticlib"]
 speech_dispatcher_0_9 = ["speech-dispatcher/0_9"]
 speech_dispatcher_0_10 = ["speech-dispatcher/0_10"]
 speech_dispatcher_0_11 = ["speech-dispatcher/0_11"]
-default = ["speech_dispatcher_0_11"]
 
 [dependencies]
 dyn-clonable = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tts"
-version = "0.25.4"
+version = "0.25.5"
 authors = ["Nolan Darilek <nolan@thewordnerd.info>"]
 repository = "https://github.com/ndarilek/tts-rs"
 description = "High-level Text-To-Speech (TTS) interface"


### PR DESCRIPTION
Allows for `cargo run --features tts/speech_dispatcher_0_1X` in a binary that uses this crate.

Because `cargo run --no-default-features --features tts/speech_dispatcher_0_10` is impossible.

I see docs are fixed now so I'll close https://github.com/ndarilek/tts-rs/issues/42#issuecomment-1497963909