### PR TITLE
Drop `ndk-glue` dependency from the main crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,6 @@ web-sys = { version = "0.3", features = [
 [target.'cfg(target_os="android")'.dependencies]
 jni = "0.21"
 ndk-context = "0.1"
-ndk-glue = "0.7"
 
 [package.metadata.docs.rs]
 no-default-features = true


### PR DESCRIPTION
Commit d42d201 ("Update Android dependencies and example.") correctly replaces `ndk-glue` with `ndk-context` as a more generic crate to hold on to a global `JavaVM` and Android `jobject` `Context`, but didn't drop the unused `ndk-glue` crate from the list of Android dependencies.  This crate is only used in the example crate, and [shouldn't clobber downstream crates].

Besides, `ndk-glue` has been deprecated for some time and should be replaced by `android-activity` in the example in a followup PR.

[shouldn't clobber downstream crates]: https://github.com/emilk/egui/pull/3606/files#r1401313794
