### PR TITLE
Use `objc2`/`objc2-avf-audio`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ windows = { version = "0.58", features = [
 [target.'cfg(target_os = "linux")'.dependencies]
 speech-dispatcher = { version = "0.16", default-features = false }
 
-[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
+[target.'cfg(target_vendor = "apple")'.dependencies]
 cocoa-foundation = "0.1"
 core-foundation = "0.9"
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,10 @@ speech-dispatcher = { version = "0.16", default-features = false }
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
 objc2 = "0.6"
+objc2-avf-audio = { version = "0.3", default-features = false, features = [
+    "std",
+    "AVSpeechSynthesis",
+] }
 objc2-foundation = { version = "0.3", default-features = false, features = [
     "std",
     "NSArray",
@@ -53,6 +57,12 @@ objc2-foundation = { version = "0.3", default-features = false, features = [
     "NSObjCRuntime",
     "NSRunLoop",
     "NSString",
+] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2-app-kit = { version = "0.3", default-features = false, features = [
+    "std",
+    "NSSpeechSynthesizer",
 ] }
 
 [target.wasm32-unknown-unknown.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,10 +44,16 @@ windows = { version = "0.58", features = [
 speech-dispatcher = { version = "0.16", default-features = false }
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
-cocoa-foundation = "0.1"
-core-foundation = "0.9"
-libc = "0.2"
-objc = { version = "0.2", features = ["exception"] }
+objc2 = "0.6"
+objc2-foundation = { version = "0.3", default-features = false, features = [
+    "std",
+    "NSArray",
+    "NSDate",
+    "NSEnumerator",
+    "NSObjCRuntime",
+    "NSRunLoop",
+    "NSString",
+] }
 
 [target.wasm32-unknown-unknown.dependencies]
 wasm-bindgen = "0.2"

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ This library provides a high-level Text-To-Speech (TTS) interface supporting var
   * Screen readers/SAPI via Tolk (requires `tolk` Cargo feature)
   * WinRT
 * Linux via [Speech Dispatcher](https://freebsoft.org/speechd)
-* MacOS/iOS
-  * AppKit on MacOS 10.13 and below
-  * AVFoundation on MacOS 10.14 and above, and iOS
+* macOS/iOS/tvOS/watchOS/visionOS.
+  * AppKit on macOS 10.13 and below.
+  * AVFoundation on macOS 10.14 and above, and iOS/tvOS/watchOS/visionOS.
 * Android
 * WebAssembly
 

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,0 @@
-fn main() {
-    if std::env::var("TARGET").unwrap().contains("-apple") {
-        println!("cargo:rustc-link-lib=framework=AVFoundation");
-        if std::env::var("CARGO_CFG_TARGET_OS").unwrap() == "macos" {
-            println!("cargo:rustc-link-lib=framework=AppKit");
-        }
-    }
-}

--- a/build.rs
+++ b/build.rs
@@ -1,10 +1,7 @@
 fn main() {
     if std::env::var("TARGET").unwrap().contains("-apple") {
         println!("cargo:rustc-link-lib=framework=AVFoundation");
-        if !std::env::var("CARGO_CFG_TARGET_OS")
-            .unwrap()
-            .contains("ios")
-        {
+        if std::env::var("CARGO_CFG_TARGET_OS").unwrap() == "macos" {
             println!("cargo:rustc-link-lib=framework=AppKit");
         }
     }

--- a/examples/99bottles.rs
+++ b/examples/99bottles.rs
@@ -1,13 +1,6 @@
 use std::io;
 use std::{thread, time};
 
-#[cfg(target_os = "macos")]
-use cocoa_foundation::base::id;
-#[cfg(target_os = "macos")]
-use cocoa_foundation::foundation::NSRunLoop;
-#[cfg(target_os = "macos")]
-use objc::{msg_send, sel, sel_impl};
-
 use tts::*;
 
 fn main() -> Result<(), Error> {
@@ -29,10 +22,8 @@ fn main() -> Result<(), Error> {
     // It shouldn't be needed in an app or game that almost certainly has one already.
     #[cfg(target_os = "macos")]
     {
-        let run_loop: id = unsafe { NSRunLoop::currentRunLoop() };
-        unsafe {
-            let _: () = msg_send![run_loop, run];
-        }
+        let run_loop = unsafe { objc2_foundation::NSRunLoop::currentRunLoop() };
+        unsafe { run_loop.run() };
     }
     io::stdin().read_line(&mut _input)?;
     Ok(())

--- a/examples/clone_drop.rs
+++ b/examples/clone_drop.rs
@@ -1,12 +1,5 @@
 use std::io;
 
-#[cfg(target_os = "macos")]
-use cocoa_foundation::base::id;
-#[cfg(target_os = "macos")]
-use cocoa_foundation::foundation::NSRunLoop;
-#[cfg(target_os = "macos")]
-use objc::{msg_send, sel, sel_impl};
-
 use tts::*;
 
 fn main() -> Result<(), Error> {
@@ -79,10 +72,8 @@ fn main() -> Result<(), Error> {
     // It shouldn't be needed in an app or game that almost certainly has one already.
     #[cfg(target_os = "macos")]
     {
-        let run_loop: id = unsafe { NSRunLoop::currentRunLoop() };
-        unsafe {
-            let _: () = msg_send![run_loop, run];
-        }
+        let run_loop = unsafe { objc2_foundation::NSRunLoop::currentRunLoop() };
+        unsafe { run_loop.run() };
     }
     io::stdin().read_line(&mut _input)?;
     Ok(())

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,12 +1,5 @@
 use std::io;
 
-#[cfg(target_os = "macos")]
-use cocoa_foundation::base::id;
-#[cfg(target_os = "macos")]
-use cocoa_foundation::foundation::NSRunLoop;
-#[cfg(target_os = "macos")]
-use objc::{msg_send, sel, sel_impl};
-
 use tts::*;
 
 fn main() -> Result<(), Error> {
@@ -94,10 +87,8 @@ fn main() -> Result<(), Error> {
     // It shouldn't be needed in an app or game that almost certainly has one already.
     #[cfg(target_os = "macos")]
     {
-        let run_loop: id = unsafe { NSRunLoop::currentRunLoop() };
-        unsafe {
-            let _: () = msg_send![run_loop, run];
-        }
+        let run_loop = unsafe { objc2_foundation::NSRunLoop::currentRunLoop() };
+        unsafe { run_loop.run() };
     }
     io::stdin().read_line(&mut _input)?;
     Ok(())

--- a/examples/ramble.rs
+++ b/examples/ramble.rs
@@ -1,13 +1,3 @@
-#[cfg(target_os = "macos")]
-use cocoa_foundation::base::id;
-#[cfg(target_os = "macos")]
-use cocoa_foundation::foundation::NSDefaultRunLoopMode;
-#[cfg(target_os = "macos")]
-use cocoa_foundation::foundation::NSRunLoop;
-#[cfg(target_os = "macos")]
-use objc::class;
-#[cfg(target_os = "macos")]
-use objc::{msg_send, sel, sel_impl};
 use std::{thread, time};
 use tts::*;
 
@@ -19,11 +9,9 @@ fn main() -> Result<(), Error> {
         tts.speak(format!("Phrase {}", phrase), false)?;
         #[cfg(target_os = "macos")]
         {
-            let run_loop: id = unsafe { NSRunLoop::currentRunLoop() };
-            unsafe {
-                let date: id = msg_send![class!(NSDate), distantFuture];
-                let _: () = msg_send![run_loop, runMode:NSDefaultRunLoopMode beforeDate:date];
-            }
+            let run_loop = unsafe { objc2_foundation::NSRunLoop::currentRunLoop() };
+            let date = unsafe { objc2_foundation::NSDate::distantFuture() };
+            unsafe { run_loop.runMode_beforeDate(objc2_foundation::NSDefaultRunLoopMode, &date) };
         }
         let time = time::Duration::from_secs(5);
         thread::sleep(time);

--- a/src/backends/appkit.rs
+++ b/src/backends/appkit.rs
@@ -1,4 +1,3 @@
-#[cfg(target_os = "macos")]
 use cocoa_foundation::base::{id, nil};
 use cocoa_foundation::foundation::NSString;
 use log::{info, trace};

--- a/src/backends/av_foundation.rs
+++ b/src/backends/av_foundation.rs
@@ -1,4 +1,3 @@
-#[cfg(any(target_os = "macos", target_os = "ios"))]
 use std::sync::Mutex;
 
 use cocoa_foundation::base::{id, nil, NO};

--- a/src/backends/av_foundation.rs
+++ b/src/backends/av_foundation.rs
@@ -52,7 +52,7 @@ impl AvFoundation {
                 let callbacks = callbacks.get_mut(&backend_id).unwrap();
                 if let Some(callback) = callbacks.utterance_begin.as_mut() {
                     trace!("Calling utterance_begin");
-                    let utterance_id = UtteranceId::AvFoundation(utterance);
+                    let utterance_id = UtteranceId::AvFoundation(utterance as usize);
                     callback(utterance_id);
                     trace!("Called");
                 }
@@ -76,7 +76,7 @@ impl AvFoundation {
                 let callbacks = callbacks.get_mut(&backend_id).unwrap();
                 if let Some(callback) = callbacks.utterance_end.as_mut() {
                     trace!("Calling utterance_end");
-                    let utterance_id = UtteranceId::AvFoundation(utterance);
+                    let utterance_id = UtteranceId::AvFoundation(utterance as usize);
                     callback(utterance_id);
                     trace!("Called");
                 }
@@ -100,7 +100,7 @@ impl AvFoundation {
                 let callbacks = callbacks.get_mut(&backend_id).unwrap();
                 if let Some(callback) = callbacks.utterance_stop.as_mut() {
                     trace!("Calling utterance_stop");
-                    let utterance_id = UtteranceId::AvFoundation(utterance);
+                    let utterance_id = UtteranceId::AvFoundation(utterance as usize);
                     callback(utterance_id);
                     trace!("Called");
                 }
@@ -203,7 +203,7 @@ impl Backend for AvFoundation {
             let _: () = msg_send![self.synth, speakUtterance: utterance];
             trace!("Done queuing");
         }
-        Ok(Some(UtteranceId::AvFoundation(utterance)))
+        Ok(Some(UtteranceId::AvFoundation(utterance as usize)))
     }
 
     fn stop(&mut self) -> Result<(), Error> {

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -13,7 +13,7 @@ mod web;
 #[cfg(target_os = "macos")]
 mod appkit;
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(target_vendor = "apple")]
 mod av_foundation;
 
 #[cfg(target_os = "android")]
@@ -34,7 +34,7 @@ pub(crate) use self::web::*;
 #[cfg(target_os = "macos")]
 pub(crate) use self::appkit::*;
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(target_vendor = "apple")]
 pub(crate) use self::av_foundation::*;
 
 #[cfg(target_os = "android")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,9 +4,9 @@
 //!  *   * Screen readers/SAPI via Tolk (requires `tolk` Cargo feature)
 //!  *   * WinRT
 //!  * * Linux via [Speech Dispatcher](https://freebsoft.org/speechd)
-//!  * * MacOS/iOS
-//!  *   * AppKit on MacOS 10.13 and below
-//!  *   * AVFoundation on MacOS 10.14 and above, and iOS
+//!  * * macOS/iOS/tvOS/watchOS/visionOS
+//!  *   * AppKit on macOS 10.13 and below.
+//!  *   * AVFoundation on macOS 10.14 and above, and iOS/tvOS/watchOS/visionOS.
 //!  * * Android
 //!  * * WebAssembly
 
@@ -44,7 +44,7 @@ pub enum Backends {
     Android,
     #[cfg(target_os = "macos")]
     AppKit,
-    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[cfg(target_vendor = "apple")]
     AvFoundation,
     #[cfg(target_os = "linux")]
     SpeechDispatcher,
@@ -63,7 +63,7 @@ impl fmt::Display for Backends {
             Backends::Android => writeln!(f, "Android"),
             #[cfg(target_os = "macos")]
             Backends::AppKit => writeln!(f, "AppKit"),
-            #[cfg(any(target_os = "macos", target_os = "ios"))]
+            #[cfg(target_vendor = "apple")]
             Backends::AvFoundation => writeln!(f, "AVFoundation"),
             #[cfg(target_os = "linux")]
             Backends::SpeechDispatcher => writeln!(f, "Speech Dispatcher"),
@@ -82,7 +82,7 @@ impl fmt::Display for Backends {
 pub enum BackendId {
     #[cfg(target_os = "android")]
     Android(u64),
-    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[cfg(target_vendor = "apple")]
     AvFoundation(u64),
     #[cfg(target_os = "linux")]
     SpeechDispatcher(usize),
@@ -97,7 +97,7 @@ impl fmt::Display for BackendId {
         match self {
             #[cfg(target_os = "android")]
             BackendId::Android(id) => writeln!(f, "Android({id})"),
-            #[cfg(any(target_os = "macos", target_os = "ios"))]
+            #[cfg(target_vendor = "apple")]
             BackendId::AvFoundation(id) => writeln!(f, "AvFoundation({id})"),
             #[cfg(target_os = "linux")]
             BackendId::SpeechDispatcher(id) => writeln!(f, "SpeechDispatcher({id})"),
@@ -114,7 +114,7 @@ impl fmt::Display for BackendId {
 pub enum UtteranceId {
     #[cfg(target_os = "android")]
     Android(u64),
-    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[cfg(target_vendor = "apple")]
     AvFoundation(usize),
     #[cfg(target_os = "linux")]
     SpeechDispatcher(u64),
@@ -131,7 +131,7 @@ impl fmt::Display for UtteranceId {
             UtteranceId::Android(id) => writeln!(f, "Android({id})"),
             #[cfg(target_os = "linux")]
             UtteranceId::SpeechDispatcher(id) => writeln!(f, "SpeechDispatcher({id})"),
-            #[cfg(any(target_os = "macos", target_os = "ios"))]
+            #[cfg(target_vendor = "apple")]
             UtteranceId::AvFoundation(id) => writeln!(f, "AvFoundation({id})"),
             #[cfg(target_arch = "wasm32")]
             UtteranceId::Web(id) => writeln!(f, "Web({})", id),
@@ -279,7 +279,7 @@ impl Tts {
             Backends::AppKit => Ok(Tts(Rc::new(RwLock::new(
                 Box::new(backends::AppKit::new()?),
             )))),
-            #[cfg(any(target_os = "macos", target_os = "ios"))]
+            #[cfg(target_vendor = "apple")]
             Backends::AvFoundation => Ok(Tts(Rc::new(RwLock::new(Box::new(
                 backends::AvFoundation::new()?,
             ))))),
@@ -333,7 +333,7 @@ impl Tts {
                 Tts::new(Backends::AppKit)
             }
         };
-        #[cfg(target_os = "ios")]
+        #[cfg(all(target_vendor = "apple", not(target_os = "macos")))]
         let tts = Tts::new(Backends::AvFoundation);
         #[cfg(target_os = "android")]
         let tts = Tts::new(Backends::Android);


### PR DESCRIPTION
This rewrites the AppKit and AVFoundation backends to use the `objc2` crates, which provide type- and memory-safety when interacting with Apple's frameworks. I recommend that you review each commit by itself.

I've tested this on macOS 14.7.1 and Mac Catalyst, and apart from the pre-existing https://github.com/ndarilek/tts-rs/issues/40, then things seem to work.

Fixes https://github.com/ndarilek/tts-rs/issues/9.
Fixes https://github.com/ndarilek/tts-rs/issues/25.
Replaces https://github.com/ndarilek/tts-rs/pull/32 (since `objc2` does this internally).
Should make https://github.com/ndarilek/tts-rs/pull/31, https://github.com/ndarilek/tts-rs/issues/46 and https://github.com/ndarilek/tts-rs/pull/26 easier to implement.