### PR TITLE
For AVFoundation backend, allow get_voice

### DIFF
--- a/examples/get_set_voice.rs
+++ b/examples/get_set_voice.rs
@@ -1,0 +1,60 @@
+use tts::*;
+
+fn main() -> Result<(), Error> {
+    env_logger::init();
+    let mut tts = Tts::default()?;
+
+    // Check to ensure we can use this feature
+    if !tts.supported_features().get_voice {
+        return Err(Error::UnsupportedFeature);
+    }
+
+    // First, lets see what the default voice is. We'll print the name, and
+    // say something in it (to ensure we can speak with it)
+    let voice_on_start = tts.voice().unwrap();
+    println!(
+        "Voice on start: {}",
+        voice_on_start
+            .as_ref()
+            .map_or("None".to_owned(), |voice: &Voice| voice.name())
+    );
+
+    if let Some(voice) = voice_on_start {
+        tts.speak(format!("The default voice is {}", voice.name()), false)?;
+    } else {
+        tts.speak("No default voice", false)?;
+    }
+
+    // Pick a different voice
+    let voices = tts.voices().unwrap();
+    let chosen_voice = &voices[5];
+
+    println!("Setting voice: {}", chosen_voice.name());
+    tts.set_voice(chosen_voice).unwrap();
+
+    // Say something with the new voice to ensure that it actually changed
+    tts.speak(format!("The new voice is {}", chosen_voice.name()), false)?;
+
+    let voice_now = &tts.voice().unwrap();
+    println!(
+        "Voice is now: {}",
+        voice_now
+            .as_ref()
+            .map_or("None".to_owned(), |voice: &Voice| voice.name())
+    );
+
+    assert_eq!(
+        voice_now.as_ref().map(|voice: &Voice| voice.name()),
+        tts.voice()?.map(|voice| voice.name())
+    );
+
+    #[cfg(target_os = "macos")]
+    {
+        let run_loop = objc2_foundation::NSRunLoop::currentRunLoop() ;
+        let date =  objc2_foundation::NSDate::distantFuture();
+        unsafe { run_loop.runMode_beforeDate(objc2_foundation::NSDefaultRunLoopMode, &date) };
+        run_loop.runUntilDate(&date);
+    }
+
+    Ok(())
+}

--- a/examples/get_set_voice.rs
+++ b/examples/get_set_voice.rs
@@ -50,8 +50,8 @@ fn main() -> Result<(), Error> {
 
     #[cfg(target_os = "macos")]
     {
-        let run_loop = objc2_foundation::NSRunLoop::currentRunLoop() ;
-        let date =  objc2_foundation::NSDate::distantFuture();
+        let run_loop = objc2_foundation::NSRunLoop::currentRunLoop();
+        let date = objc2_foundation::NSDate::distantFuture();
         unsafe { run_loop.runMode_beforeDate(objc2_foundation::NSDefaultRunLoopMode, &date) };
         run_loop.runUntilDate(&date);
     }

--- a/src/backends/av_foundation.rs
+++ b/src/backends/av_foundation.rs
@@ -142,10 +142,10 @@ impl AvFoundation {
         Ok(rv)
     }
 
-     fn default_voice(&self) -> Result<Voice, Error> {
-         unsafe { AVSpeechSynthesisVoice::voiceWithLanguage(None) }
-         .map(Voice::from_av_speech_synthesis_voice)
-         .ok_or(Error::OperationFailed)
+    fn default_voice(&self) -> Result<Voice, Error> {
+        unsafe { AVSpeechSynthesisVoice::voiceWithLanguage(None) }
+            .map(Voice::from_av_speech_synthesis_voice)
+            .ok_or(Error::OperationFailed)
     }
 }
 
@@ -295,8 +295,10 @@ impl Backend for AvFoundation {
     }
 
     fn set_voice(&mut self, voice: &Voice) -> Result<(), Error> {
-        let voice = unsafe {AVSpeechSynthesisVoice::voiceWithIdentifier(&NSString::from_str(&voice.id()))}
-            .ok_or(Error::OperationFailed)?;
+        let voice = unsafe {
+            AVSpeechSynthesisVoice::voiceWithIdentifier(&NSString::from_str(&voice.id()))
+        }
+        .ok_or(Error::OperationFailed)?;
         self.voice = Some(voice);
         Ok(())
     }
@@ -304,9 +306,9 @@ impl Backend for AvFoundation {
 
 impl Voice {
     pub fn from_av_speech_synthesis_voice(voice: Retained<AVSpeechSynthesisVoice>) -> Voice {
-        let id = unsafe {voice.identifier()};
-        let name = unsafe {voice.name()};
-        let gender = unsafe {voice.gender()};
+        let id = unsafe { voice.identifier() };
+        let name = unsafe { voice.name() };
+        let gender = unsafe { voice.gender() };
         let gender = match gender {
             AVSpeechSynthesisVoiceGender::Male => Some(Gender::Male),
             AVSpeechSynthesisVoiceGender::Female => Some(Gender::Female),
@@ -315,7 +317,7 @@ impl Voice {
 
         // Apple documents that the language is a BCP 47 language tag, which is compatible with the LanguageTag crate
         // https://developer.apple.com/documentation/avfaudio/avspeechsynthesisvoice/language
-        let language = unsafe {voice.language()}.to_string();
+        let language = unsafe { voice.language() }.to_string();
         let language = LanguageTag::parse_and_normalize(&language).unwrap();
         Voice {
             id: id.to_string(),

--- a/src/backends/av_foundation.rs
+++ b/src/backends/av_foundation.rs
@@ -106,7 +106,7 @@ pub(crate) struct AvFoundation {
     rate: f32,
     volume: f32,
     pitch: f32,
-    voice: Option<Voice>,
+    voice: Option<Retained<AVSpeechSynthesisVoice>>,
 }
 
 lazy_static! {
@@ -141,6 +141,12 @@ impl AvFoundation {
         *backend_id += 1;
         Ok(rv)
     }
+
+     fn default_voice(&self) -> Result<Voice, Error> {
+         unsafe { AVSpeechSynthesisVoice::voiceWithLanguage(None) }
+         .map(Voice::from_av_speech_synthesis_voice)
+         .ok_or(Error::OperationFailed)
+    }
 }
 
 impl Backend for AvFoundation {
@@ -156,7 +162,7 @@ impl Backend for AvFoundation {
             volume: true,
             is_speaking: true,
             voice: true,
-            get_voice: false,
+            get_voice: true,
             utterance_callbacks: true,
         }
     }
@@ -179,10 +185,7 @@ impl Backend for AvFoundation {
             trace!("Setting pitch to {}", self.pitch);
             utterance.setPitchMultiplier(self.pitch);
             if let Some(voice) = &self.voice {
-                let vid = NSString::from_str(&voice.id());
-                let v = AVSpeechSynthesisVoice::voiceWithIdentifier(&*vid)
-                    .ok_or(Error::OperationFailed)?;
-                utterance.setVoice(Some(&v));
+                utterance.setVoice(Some(voice));
             }
             trace!("Enqueuing");
             self.synth.speakUtterance(&utterance);
@@ -275,38 +278,50 @@ impl Backend for AvFoundation {
     }
 
     fn voice(&self) -> Result<Option<Voice>, Error> {
-        unimplemented!()
+        if let Some(voice) = self.voice.clone() {
+            Ok(Some(Voice::from_av_speech_synthesis_voice(voice)))
+        } else {
+            Ok(Some(self.default_voice()?))
+        }
     }
 
     fn voices(&self) -> Result<Vec<Voice>, Error> {
         let voices = unsafe { AVSpeechSynthesisVoice::speechVoices() };
         let rv = voices
             .iter()
-            .map(|v| {
-                let id = unsafe { v.identifier() };
-                let name = unsafe { v.name() };
-                let gender = unsafe { v.gender() };
-                let gender = match gender {
-                    AVSpeechSynthesisVoiceGender::Male => Some(Gender::Male),
-                    AVSpeechSynthesisVoiceGender::Female => Some(Gender::Female),
-                    _ => None,
-                };
-                let language = unsafe { v.language() };
-                let language = language.to_string();
-                let language = LanguageTag::parse(language).unwrap();
-                Voice {
-                    id: id.to_string(),
-                    name: name.to_string(),
-                    gender,
-                    language,
-                }
-            })
+            .map(Voice::from_av_speech_synthesis_voice)
             .collect();
         Ok(rv)
     }
 
     fn set_voice(&mut self, voice: &Voice) -> Result<(), Error> {
-        self.voice = Some(voice.clone());
+        let voice = unsafe {AVSpeechSynthesisVoice::voiceWithIdentifier(&NSString::from_str(&voice.id()))}
+            .ok_or(Error::OperationFailed)?;
+        self.voice = Some(voice);
         Ok(())
+    }
+}
+
+impl Voice {
+    pub fn from_av_speech_synthesis_voice(voice: Retained<AVSpeechSynthesisVoice>) -> Voice {
+        let id = unsafe {voice.identifier()};
+        let name = unsafe {voice.name()};
+        let gender = unsafe {voice.gender()};
+        let gender = match gender {
+            AVSpeechSynthesisVoiceGender::Male => Some(Gender::Male),
+            AVSpeechSynthesisVoiceGender::Female => Some(Gender::Female),
+            _ => None,
+        };
+
+        // Apple documents that the language is a BCP 47 language tag, which is compatible with the LanguageTag crate
+        // https://developer.apple.com/documentation/avfaudio/avspeechsynthesisvoice/language
+        let language = unsafe {voice.language()}.to_string();
+        let language = LanguageTag::parse_and_normalize(&language).unwrap();
+        Voice {
+            id: id.to_string(),
+            name: name.to_string(),
+            gender,
+            language,
+        }
     }
 }


### PR DESCRIPTION
This is an updated version of #26, which is much cleaner thanks to @madsmtm 's work to move the crate to `objc2` in #57.

This change adds the ability to get the current voice (`get_voice()`) in AVFoundation. This is either the most recent voice passed to set_voice(), or the system default voice.

Other significant changes:
* An example, `get_set_voice`, changes the voice from the default voice arbitrarily to show that the voice changing functionality works, and the voice name can be retrieved.
* Voice for the `AVSpeechSynthesizer` backed are stored directly as `AVSpeechSynthesisVoice` instead of the native `Voice`. That avoids a redundant voice lookup for each utterance, but should not change the external interface at all.